### PR TITLE
Ensure the player isn't an npc on teleport and move events.

### DIFF
--- a/src/main/java/me/lxct/bestviewdistance/event/OnPlayerMove.java
+++ b/src/main/java/me/lxct/bestviewdistance/event/OnPlayerMove.java
@@ -11,6 +11,10 @@ import org.bukkit.event.player.PlayerMoveEvent;
 public class OnPlayerMove implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public static void playerMove(final PlayerMoveEvent e) {
+        if (e.getPlayer().hasMetadata("NPC")) {
+            return;
+        }
+
         // Unset Afk with Async Method...
         Bukkit.getScheduler().runTaskAsynchronously(BestViewDistance.plugin, new UnsetAfk(e));
     }

--- a/src/main/java/me/lxct/bestviewdistance/event/OnTeleport.java
+++ b/src/main/java/me/lxct/bestviewdistance/event/OnTeleport.java
@@ -20,6 +20,10 @@ public class OnTeleport implements Listener {
     @EventHandler(priority = EventPriority.MONITOR)
     public static void onPlayerTeleport(final PlayerTeleportEvent e) {
         final Player p = e.getPlayer();
+        if (p.hasMetadata("NPC")) {
+            return;
+        }
+
         final BVDPlayer player = onlinePlayers.get(p);
         if (!e.getCause().equals(CHORUS_FRUIT) && !e.getCause().equals(UNKNOWN) && !e.getCause().equals(ENDER_PEARL)) {
             if (player.isViewBypass() && permissionsBypassTeleport) {


### PR DESCRIPTION
Fixes #14, or at least it should
since I have yet to test it.