### PR TITLE
When unsetting afk player, ensure they still exist.

### DIFF
--- a/src/main/java/me/lxct/bestviewdistance/functions/async/UnsetAfk.java
+++ b/src/main/java/me/lxct/bestviewdistance/functions/async/UnsetAfk.java
@@ -2,6 +2,8 @@ package me.lxct.bestviewdistance.functions.async;
 
 import org.bukkit.event.player.PlayerMoveEvent;
 
+import me.lxct.bestviewdistance.functions.BVDPlayer;
+
 import static me.lxct.bestviewdistance.functions.data.Variable.onlinePlayers;
 
 public class UnsetAfk implements Runnable {
@@ -13,6 +15,17 @@ public class UnsetAfk implements Runnable {
 
     @Override
     public void run() {
-        onlinePlayers.get(e.getPlayer()).setAfk(false);
+        // Since this is an async task, the player could have logged off
+        // this usually happens if they lag or the server lags
+        if (e.getPlayer() == null) {
+            return;
+        }
+
+        BVDPlayer p = onlinePlayers.get(e.getPlayer());
+        if (p == null) {
+            return;
+        }
+
+        p.setAfk(false);
     }
 }


### PR DESCRIPTION
This fixes #16 and is usually the result of players logging off
or the server lagging and the async task running after they
have logged off the server.