### PR TITLE
More checks to ensure the player isn't null.

### DIFF
--- a/src/main/java/me/lxct/bestviewdistance/functions/async/TeleportData.java
+++ b/src/main/java/me/lxct/bestviewdistance/functions/async/TeleportData.java
@@ -21,6 +21,10 @@ public class TeleportData implements Runnable {
     @Override
     public void run() {
         final BVDPlayer player = onlinePlayers.get(p);
+        if (player == null) {
+            return;
+        }
+
         if (player.isWaitingForTpUnset()) { // If he is waiting for TP UNSET
             Bukkit.getScheduler().cancelTask(player.getTpTaskId()); // Cancel task if the player got a task
             player.setWaitingForTpUnset(false); // Remove waiting

--- a/src/main/java/me/lxct/bestviewdistance/functions/async/UnsetTeleport.java
+++ b/src/main/java/me/lxct/bestviewdistance/functions/async/UnsetTeleport.java
@@ -2,6 +2,8 @@ package me.lxct.bestviewdistance.functions.async;
 
 import org.bukkit.entity.Player;
 
+import me.lxct.bestviewdistance.functions.BVDPlayer;
+
 import static me.lxct.bestviewdistance.functions.data.Variable.onlinePlayers;
 
 public class UnsetTeleport implements Runnable {
@@ -13,6 +15,15 @@ public class UnsetTeleport implements Runnable {
 
     @Override
     public void run() {
-        onlinePlayers.get(p).setWaitingForTpUnset(false);
+        if (p == null) {
+            return;
+        }
+
+        BVDPlayer pl = onlinePlayers.get(p);
+        if (pl == null) {
+            return;
+        }
+
+        pl.setWaitingForTpUnset(false);
     }
 }


### PR DESCRIPTION
This time it fixes #22. Any async tasks
can return the player as null since
the server could have lagged and
the user got disconnected.